### PR TITLE
Closing #80

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -13,7 +13,7 @@ import { BrowserRouter as Router, Switch, Route, Link, withRouter } from "react-
 import { Nav, Navbar, Container, Button, Modal } from 'react-bootstrap';
 import { ChevronLeft, CheckCircle, ExclamationTriangle, HourglassSplit, XCircle } from 'react-bootstrap-icons';
 import { Trans } from 'react-i18next';
-import { GetLanguage, LogIn, checkAuth, initWeb3, initWeb3Modal } from '../util/Utilities';
+import { GetLanguage, LogIn, checkAuth, initWeb3, initWeb3Modal, clearWeb3Provider } from '../util/Utilities';
 import axios from 'axios';
 import config from 'react-global-configuration';
 import i18n from '../util/i18n';
@@ -57,10 +57,7 @@ class App extends Component {
 
     async setLoggedIn() {
         if(this.state.isLoggedIn) {
-            if(this.state.web3 && this.state.web3.currentProvider && this.state.web3.currentProvider.close) {
-                await this.state.web3.currentProvider.close();
-                await window.web3Modal.clearCachedProvider();
-            }
+            await clearWeb3Provider(this);
             await axios.post('/api/auth/logout');
             this.setState({isLoggedIn : false});
             this.props.history.push('/');
@@ -80,6 +77,7 @@ class App extends Component {
                         modalButtonMessage: 'closeBtn',
                         modalButtonVariant: "#E63C36"}
                     );
+                    await clearWeb3Provider(this);
                 }
             } catch (err) {
                 console.log(err);
@@ -90,6 +88,7 @@ class App extends Component {
                     modalButtonMessage: 'closeBtn',
                     modalButtonVariant: "#E63C36"}
                 );
+                await clearWeb3Provider(this);
             }
 
         }
@@ -171,7 +170,10 @@ class App extends Component {
                                             borderColor: this.state.modalButtonVariant
                                         }}
                                         onClick={() => {
-                                            this.setState({showModal: false})
+                                            if(this.state.onModalClose) {
+                                                this.state.onModalClose();
+                                            }
+                                            this.setState({showModal: false, onModalClose: false});
                                         }}>
                                     <Trans i18nKey={this.state.modalButtonMessage} />
                                 </Button>

--- a/src/components/CampaignPage.js
+++ b/src/components/CampaignPage.js
@@ -6,7 +6,7 @@ import { ChevronLeft, Gift, CheckCircle, ExclamationTriangle, HourglassSplit, XC
 import ReactPlayer from 'react-player';
 import { Link } from "react-router-dom";
 import { Trans } from 'react-i18next';
-import { initWeb3, initWeb3Modal } from '../util/Utilities';
+import { initWeb3, initWeb3Modal, clearWeb3Provider } from '../util/Utilities';
 import i18n from '../util/i18n';
 import countryMap from '../countryMap';
 import { Editor, EditorState, convertFromRaw, CompositeDecorator } from "draft-js";
@@ -142,7 +142,13 @@ class CampaignPage extends Component {
                 this.setState({
                     showModal: true, modalTitle: 'processingWait',
                     modalMessage: "approveSpend",
-                    errorIcon: 'HourglassSplit', modalButtonVariant: "gold", waitToClose: true
+                    errorIcon: 'HourglassSplit', modalButtonVariant: "#E63C36", waitToClose: false,
+                    modalButtonMessage: 'abortBtn',
+                    onModalClose: function() {
+                        if(clearWeb3Provider(that)) {
+                            clearWeb3Provider(that);
+                        }
+                    }
                 });
                 try {
                     let result = await coinInstance.methods.approve(this.state.campaign._id, toDonate).send(
@@ -174,6 +180,7 @@ class CampaignPage extends Component {
                         modalButtonVariant: '#E63C36', waitToClose: false,
                         modalMessage: 'blockChainTransactionFailed'
                     });
+                    clearWeb3Provider(this)
                     console.log(err);
                 }
             }
@@ -206,7 +213,13 @@ class CampaignPage extends Component {
                         {!this.state.waitToClose &&
                         <Button className='myModalButton' 
                             style={{backgroundColor : this.state.modalButtonVariant, borderColor : this.state.modalButtonVariant}} 
-                            onClick={ () => {this.setState({showModal:false})}}>
+                            onClick={ () => {
+                                    if(this.state.onModalClose) {
+                                        this.state.onModalClose();
+                                    }
+                                    this.setState({showModal: false, onModalClose: false});
+                                }
+                            }>
                             <Trans i18nKey={this.state.modalButtonMessage} />
                         </Button>
                         }

--- a/src/lang/translationEN.json
+++ b/src/lang/translationEN.json
@@ -57,6 +57,7 @@
     "complete" : "Complete!",
     "updateSuccessfull" : "Updated Campaign information successfully",
     "closeBtn" : "CLOSE",
+    "abortBtn" : "ABORT",
     "web3WalletRequired": "Web3 Wallet is Required",
     "authFailedTitle": "Login failed",
     "authFailedMessage": "Authentication failed. Please check your wallet app for details",

--- a/src/lang/translationRU.json
+++ b/src/lang/translationRU.json
@@ -53,6 +53,7 @@
     "complete" : "Успешно!",
     "updateSuccessfull" : "Updated Campaign information successfully",
     "closeBtn" : "ЗАКРЫТЬ",
+    "abortBtn" : "ОТМЕНИТЬ",
     "nonWLTitle": "Не разрешено",
     "nonWLMessage": "Вам не разрешено заводить кампании. Пожалуйста заполните эту <1>форму</1> чтобы быть получить разрешение на сбор пожертвований через HEO Platform",
     "updatingCampaignOnBlockchain": "Сохраняем новые данные кампании в блокчейн...",

--- a/src/util/Utilities.js
+++ b/src/util/Utilities.js
@@ -10,10 +10,23 @@ class Utilities {
 
 }
 
+const clearWeb3Provider= async (that) => {
+    if(that.state.web3 && that.state.web3.currentProvider && that.state.web3.currentProvider.close) {
+        await that.state.web3.currentProvider.close();
+    }
+    if(window.web3Modal) {
+        await window.web3Modal.clearCachedProvider();
+    }
+}
+
 const LogIn = async (accountAdd, web3, that) => {
     that.setState({showModal:true, modalTitle: '',
         modalMessage: 'signThePhrase', modalIcon: 'HourglassSplit',
-        modalButtonVariant: "gold", waitToClose: true});
+        modalButtonVariant: "#E63C36", waitToClose: false, modalButtonMessage: 'abortBtn',
+            onModalClose: function() {
+                clearWeb3Provider(that);
+            }
+        });
     let res = await axios.get('/api/auth/msg');
     let dataToSign = res.data.dataToSign;
     let signature = await web3.eth.personal.sign(dataToSign, accountAdd);
@@ -123,5 +136,5 @@ const initWeb3Modal = async() => {
         });
     }
 }
-export {DescriptionPreview, GetLanguage, LogIn, initWeb3, checkAuth, initWeb3Modal };
+export {DescriptionPreview, GetLanguage, LogIn, initWeb3, checkAuth, initWeb3Modal, clearWeb3Provider };
 export default Utilities;


### PR DESCRIPTION
(Closing #80 )
Clear web3provider cache when login fails

Add 'Abort' button to wait popups, so that
user does not get stuck if mobile app does not respond

When add a callback to execute after Abort is clicked
via state