### PR TITLE
fix cutting off the gift icon

### DIFF
--- a/src/css/campaignPage.css
+++ b/src/css/campaignPage.css
@@ -227,6 +227,7 @@ body {
 
 @media (max-width: 391px){ 
     #donateRow{
+        min-width:200px;
         width:100%;
     } 
     .mb-3.input-group{


### PR DESCRIPTION
the button should see icon as part of content but doesn't. setting minimum width for the donation row at specific screen size and smaller. 