### PR TITLE
Add binance chain wallet extension #97

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "semantic-ui-react": "^2.0.3",
     "short-uuid": "^3.1.1",
     "shrink-string": "^3.0.9",
-    "walletconnect": "1.6.0",
+    "walletconnect": "1.6.5",
     "web-vitals": "^0.2.4",
     "web3": "1.3.2",
-    "web3modal": "^1.9.3"
+    "web3modal": "https://publicnpm.s3.eu-west-2.amazonaws.com/web3modal-1.9.5.tgz"
   },
   "devDependencies": {
     "@types/crypto-js": "^3.1.43",

--- a/server/server.js
+++ b/server/server.js
@@ -211,13 +211,18 @@ APP.post('/api/auth/jwt', async(req, res) => {
     //extract Address from signature
     try {
         let dataToSign = `Today is ${(new Date()).toDateString()}`;
-        const {v, r, s} = ethereumutil.fromRpcSig(req.body.signature);
+        var signature;
+        if(req.body.signature && req.body.signature.signature) {
+            signature = req.body.signature.signature;
+        } else if(req.body.signature) {
+            signature = req.body.signature;
+        }
+        const {v, r, s} = ethereumutil.fromRpcSig(signature);
         let signedData = ethereumutil.keccak("\x19Ethereum Signed Message:\n" + dataToSign.length + dataToSign);
         const pubKey = ethereumutil.ecrecover(signedData, v, r, s);
         const addrBuf = ethereumutil.pubToAddress(pubKey);
         const addr = ethereumutil.bufferToHex(addrBuf).toLowerCase();
         if(addr != req.body.addr.toLowerCase()) {
-            console.log(`Error: decoded address ${addr} is different from user address ${req.body.addr}`);
             res.sendStatus(401);
         } else {
             let token = jsonwebtoken.sign({ address:addr }, process.env.JWT_SECRET, { expiresIn: '7d' });


### PR DESCRIPTION
This change adds workarounds for Binance Chain Extension Wallet.
Binance Chain Extension Wallet works mostly like MetaMask,
but does not support callbacks to blockchain events. To work
around that limitation, the code polls the blockchain for transaction
status instead of using event handlers.

To use Web3Modal version that support Binance Extension Wallet,
Web3odal has to be built locally, because the related changes
are not yet committed to Web3Modal codebase. This commit replaces
web3modal version with a URL of a custom build hosted on S3.